### PR TITLE
base64前缀重复

### DIFF
--- a/draw_card/create_img.py
+++ b/draw_card/create_img.py
@@ -62,6 +62,6 @@ class CreateImg:
         buf = BytesIO()
         self.markImg.save(buf, format='PNG')
         base64_str = base64.b64encode(buf.getvalue()).decode()
-        return 'base64://' + base64_str
+        return base64_str
 
 


### PR DESCRIPTION
base64://前缀在抽卡handle部分代码和create_img代码中都出现了 导致图片发送不出去