### PR TITLE
修复了某些池子六星名称显示错误的问题

### DIFF
--- a/draw_card/handles/prts_handle.py
+++ b/draw_card/handles/prts_handle.py
@@ -247,6 +247,10 @@ class PrtsHandle(BaseHandle[Operator]):
                         if match:
                             time = match.group(1)
                         if "★" in line:
+                            """这里修复了某些池子六星名称显示错误的问题(如奔崖号角)"""
+                            if line[0] != '★':
+                                idx = line.find('★')
+                                line = line[idx:]
                             chars.append(line)
                     if not time:
                         continue


### PR DESCRIPTION
因为鹰角的诡异排版，“活动期间【奔崖怒号】限时寻访开启，该寻访中以下干员出现率上升”与六星信息是在同一个<p>标签下的，所以获取up池信息时会显示错误