### PR TITLE
fix: 干员图片文件重名问题

### DIFF
--- a/draw_card/util.py
+++ b/draw_card/util.py
@@ -9,8 +9,9 @@ dir_path = Path(__file__).parent.absolute()
 
 
 def cn2py(word) -> str:
+    """保存声调，防止出现类似方舟干员红与吽拼音相同声调不同导致红照片无法保存的问题"""
     temp = ""
-    for i in pypinyin.pinyin(word, style=pypinyin.NORMAL):
+    for i in pypinyin.pinyin(word, style=pypinyin.pypinyin.TONE3):
         temp += "".join(i)
     return temp
 


### PR DESCRIPTION
修改 cn2py `pypinyin.NORMAL` -> `pypinyin.TONE3`
修复相同拼音不同声调会使干员图片丢失（比如红与吽实际保存吽的头像）