### PR TITLE
修复了方舟重载卡池时的错误

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="68ce31f6-02d3-4cd5-a6ab-3887e415e651" name="变更" comment="变更">
+      <change beforePath="$PROJECT_DIR$/draw_card/handles/prts_handle.py" beforeDir="false" afterPath="$PROJECT_DIR$/draw_card/handles/prts_handle.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pyproject.toml" beforeDir="false" afterPath="$PROJECT_DIR$/pyproject.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/requirements.txt" beforeDir="false" afterPath="$PROJECT_DIR$/requirements.txt" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="29epfF4syOhiRKQmj3TVcjCofXX" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true">
+    <ConfirmationsSetting value="2" id="Add" />
+  </component>
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_ADD_EXTERNAL_FILES": "true",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "last_opened_file_path": "E:/_Joy/Nonebot/Shiruku/Shiruku/plugins/drawCard/handles/prts_handle.py",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "reference.settingsdialog.IDE.editor.colors.Python",
+    "two.files.diff.last.used.file": "E:/_Joy/Nonebot/Shiruku/Shiruku/plugins/drawCard/handles/prts_handle.py",
+    "vue.rearranger.settings.migration": "true"
+  },
+  "keyToStringList": {
+    "com.intellij.ide.scratch.ScratchImplUtil$2/新建临时文件": [
+      "Python",
+      "Cython"
+    ]
+  }
+}]]></component>
+  <component name="RunManager" selected="Python.prts_handle">
+    <configuration name="prts_handle" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="nonebot_plugin_gamedraw" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/draw_card/handles" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/draw_card/handles/prts_handle.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <configuration name="scratch" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="nonebot_plugin_gamedraw" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$APPLICATION_CONFIG_DIR$/scratches" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="$APPLICATION_CONFIG_DIR$/scratches/scratch.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <configuration name="scratch_24" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="nonebot_plugin_gamedraw" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$APPLICATION_CONFIG_DIR$/scratches" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="$APPLICATION_CONFIG_DIR$/scratches/scratch_24.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Python.prts_handle" />
+        <item itemvalue="Python.scratch" />
+        <item itemvalue="Python.scratch_24" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="应用程序级" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="默认任务">
+      <changelist id="68ce31f6-02d3-4cd5-a6ab-3887e415e651" name="变更" comment="" />
+      <created>1653483525083</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1653483525083</updated>
+      <workItem from="1653483548719" duration="1363000" />
+      <workItem from="1653530740712" duration="31000" />
+      <workItem from="1653534638851" duration="4614000" />
+      <workItem from="1653548733127" duration="178000" />
+      <workItem from="1653548928336" duration="4668000" />
+      <workItem from="1653553656905" duration="5967000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <option name="ADD_EXTERNAL_FILES_SILENTLY" value="true" />
+  </component>
+  <component name="com.intellij.coverage.CoverageDataManagerImpl">
+    <SUITE FILE_PATH="coverage/nonebot_plugin_gamedraw$scratch_24.coverage" NAME="scratch_24 覆盖结果" MODIFIED="1653538818868" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$APPLICATION_CONFIG_DIR$/scratches" />
+    <SUITE FILE_PATH="coverage/nonebot_plugin_gamedraw$prts_handle.coverage" NAME="prts_handle 覆盖结果" MODIFIED="1653563006234" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/draw_card/handles" />
+    <SUITE FILE_PATH="coverage/nonebot_plugin_gamedraw$scratch.coverage" NAME="scratch 覆盖结果" MODIFIED="1653553216316" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$APPLICATION_CONFIG_DIR$/scratches" />
+  </component>
+</project>

--- a/draw_card/handles/prts_handle.py
+++ b/draw_card/handles/prts_handle.py
@@ -1,15 +1,15 @@
-import re
 import random
-import dateparser
-from lxml import etree
-from PIL import ImageDraw
-from bs4 import BeautifulSoup
+import re
 from datetime import datetime
-from urllib.parse import unquote
 from typing import List, Optional, Tuple
-from pydantic import ValidationError
+from urllib.parse import unquote
+
+import dateparser
+from PIL import ImageDraw
+from lxml import etree
 from nonebot.adapters.onebot.v11 import Message, MessageSegment
 from nonebot.log import logger
+from pydantic import ValidationError
 
 try:
     import ujson as json
@@ -17,7 +17,7 @@ except ModuleNotFoundError:
     import json
 
 from .base_handle import BaseHandle, BaseData, UpChar, UpEvent
-from ..config import draw_config, DRAW_PATH
+from ..config import draw_config
 from ..util import remove_prohibited_str, cn2py, load_font
 from ..build_image import BuildImage
 
@@ -30,7 +30,7 @@ class Operator(BaseData):
 
 class PrtsHandle(BaseHandle[Operator]):
     def __init__(self):
-        super().__init__("prts", "明日方舟")
+        super().__init__(game_name="prts", game_name_cn="明日方舟")
         self.max_star = 6
         self.game_card_color = "#eff2f5"
         self.config = draw_config.prts
@@ -40,8 +40,8 @@ class PrtsHandle(BaseHandle[Operator]):
 
     def get_card(self, add: float) -> Operator:
         star = self.get_star(
-            [6, 5, 4, 3],
-            [
+            star_list=[6, 5, 4, 3],
+            probability_list=[
                 self.config.PRTS_SIX_P + add,
                 self.config.PRTS_FIVE_P,
                 self.config.PRTS_FOUR_P,
@@ -73,7 +73,7 @@ class PrtsHandle(BaseHandle[Operator]):
             acquire_operator = random.choice(all_operators)
         return acquire_operator
 
-    def get_cards(self, count: int) -> List[Tuple[Operator, int]]:
+    def get_cards(self, count: int, **kwargs) -> List[Tuple[Operator, int]]:
         card_list = []  # 获取所有角色
         add = 0.0
         count_idx = 0
@@ -162,8 +162,11 @@ class PrtsHandle(BaseHandle[Operator]):
 
     def load_up_char(self):
         try:
-            if (DRAW_PATH / "draw_card_up" / f"{self.game_name}_up_char.json").exists():
-                data = self.load_data(f"draw_card_up/{self.game_name}_up_char.json")
+            data = self.load_data(f"draw_card_up/{self.game_name}_up_char.json")
+            """这里的 waring 有点模糊，更新游戏信息时没有up池的情况下也会报错，所以细分了一下"""
+            if not data:
+                logger.warning(f"当前无UP池或 {self.game_name}_up_char.json 文件不存在")
+            else:
                 self.UP_EVENT = UpEvent.parse_obj(data.get("char", {}))
         except ValidationError:
             logger.warning(f"{self.game_name}_up_char 解析出错")
@@ -174,6 +177,7 @@ class PrtsHandle(BaseHandle[Operator]):
             self.dump_data(data, f"draw_card_up/{self.game_name}_up_char.json")
 
     async def _update_info(self):
+        """更新信息"""
         info = {}
         url = "https://wiki.biligame.com/arknights/干员数据表"
         result = await self.get_url(url)
@@ -211,6 +215,7 @@ class PrtsHandle(BaseHandle[Operator]):
         await self.update_up_char()
 
     async def update_up_char(self):
+        """重载卡池"""
         announcement_url = "https://ak.hypergryph.com/news.html"
         result = await self.get_url(announcement_url)
         if not result:
@@ -224,45 +229,53 @@ class PrtsHandle(BaseHandle[Operator]):
         end_time = None
         up_chars = []
         pool_img = ""
-        title = ""
-        for activity_url in activity_urls:
+        for activity_url in activity_urls[:10]:  # 减少响应时间, 10个就够了
             activity_url = f"https://ak.hypergryph.com{activity_url}"
             result = await self.get_url(activity_url)
             if not result:
                 logger.warning(f"{self.game_name_cn}获取公告 {activity_url} 出错")
                 continue
-            soup = BeautifulSoup(result, "lxml")
-            contents = soup.find_all("p")
+
+            """因为鹰角的前端太自由了，这里重写了匹配规则以尽可能避免因为前端乱七八糟而导致的重载失败"""
+            dom = etree.HTML(result, etree.HTMLParser())
+            contents = dom.xpath(
+                "//div[@class='article-content']/p/text() | //div[@class='article-content']/p/span/text() | //div[@class='article-content']/div[@class='media-wrap image-wrap']/img/@src"
+            )
+            title = ""
+            time = ""
+            chars: List[str] = []
             for index, content in enumerate(contents):
-                if re.search("(.*)(寻访|复刻).*?开启", content.text):
-                    title = content.text
-                    if "【" in title and "】" in title:
-                        title = re.split(r"[【】]", title)[1]
-                    lines = [str(contents[index + i + 1].text) for i in range(5)]
-                    time = ""
-                    chars: List[str] = []
-                    for line in lines:
+                if re.search("(.*)(寻访|复刻).*?开启", content):
+                    title = re.split(r"[【】]", content)
+                    title = "".join(title[1:-1]) if "-" in title else title[1]
+                    lines = [contents[index-2+_] for _ in range(8)]  # 从 -2 开始是因为xpath获取的时间有的会在寻访开启这一句之前
+                    lines.append("")  # 防止IndexError，加个空字符串
+                    for idx, line in enumerate(lines):
                         match = re.search(
                             r"(\d{1,2}月\d{1,2}日.*?-.*?\d{1,2}月\d{1,2}日.*?$)", line
                         )
                         if match:
                             time = match.group(1)
-                        if "★" in line:
-                            """这里修复了某些池子六星名称显示错误的问题(如奔崖号角)"""
-                            if line[0] != '★':
-                                idx = line.find('★')
-                                line = line[idx:]
-                            chars.append(line)
+                        """因为 <p> 的诡异排版，所以有了下面的一段"""
+                        if ("★★" in line and "%" in line) or ("★★" in line and "%" in lines[idx + 1]):
+                            chars.append(line) if ("★★" in line and "%" in line) else chars.append(line + lines[idx + 1])
                     if not time:
                         continue
-                    start, end = time.replace("月", "/").replace("日", "").split("-")[:2]
+                    start, end = time.replace("月", "/").replace("日", " ").split("-")[:2]  # 日替换为空格是因为有日后面不接空格的情况，导致 split 出问题
                     start_time = dateparser.parse(start)
                     end_time = dateparser.parse(end)
-                    pool_img = content.find_previous("img")["src"]
+                    pool_img = contents[index-2]
+                    r"""两类格式：用/分割，用\分割；★+(概率)+名字，★+名字+(概率)"""
                     for char in chars:
                         star = char.split("（")[0].count("★")
-                        name = re.split(r"[：（]", char)[1]
-                        names = name.split("/") if "/" in name else [name]
+                        name = re.split(r"[：（]", char)[1] if "★（" not in char else re.split("）：", char)[1]  # 有的括号在前面有的在后面
+                        if "\\" in name:
+                            names = name.split("\\")
+                        elif "/" in name:
+                            names = name.split("/")
+                        else:
+                            names = [name]  # 既有用/分割的，又有用\分割的
+
                         names = [name.replace("[限定]", "").strip() for name in names]
                         if "权值" in char:
                             match = re.search(r"（在.*?以.*?(\d+).*?倍权值.*?）", char)
@@ -276,7 +289,7 @@ class PrtsHandle(BaseHandle[Operator]):
                             up_chars.append(
                                 UpChar(name=name, star=star, limited=False, zoom=zoom)
                             )
-                    break
+                    break  # 这里break会导致个问题：如果一个公告里有两个池子，会漏掉下面的池子，比如 5.19 的定向寻访。但目前我也没啥好想法解决
             if title and start_time and end_time:
                 if start_time <= datetime.now() <= end_time:
                     self.UP_EVENT = UpEvent(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ nonebot-adapter-onebot = "^2.0.0-beta.1"
 nonebot-plugin-apscheduler = "^0.1.2"
 aiofiles = "^0.8.0"
 aiohttp = "^3.7.4"
-beautifulsoup4 = "^4.9.3"
 cachetools = "^5.0.0"
 cn2an = "^0.5.16"
 dateparser = "^1.1.0"
@@ -23,7 +22,7 @@ lxml = "^4.6.3"
 Pillow = "^8.2.0"
 pypinyin = "^0.42.0"
 typing-extensions = ">=3.10.0,<5.0.0"
-ujson = {version = "^4.0.2", optional = true}
+ujson = {version = "^5.1.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 nb-cli = "^0.6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ aiofiles==0.7.0
 aiohttp==3.7.4.post0
 async-timeout==3.0.1
 attrs==21.2.0
-beautifulsoup4==4.9.3
-bs4==0.0.1
 chardet==4.0.0
 idna==3.2
 multidict==5.1.0
@@ -11,6 +9,6 @@ Pillow==8.2.0
 pypinyin==0.42.0
 soupsieve==2.2.1
 typing-extensions==3.10.0.0
-ujson==4.0.2
+ujson==5.1.0
 yarl==1.6.3
 lxml==4.6.3


### PR DESCRIPTION
因为有个低危漏洞，所以把ujson版本提到了5.1.0

因为鹰角的前端太自由了，所以干脆丢掉了bs4库，用lxml重写了匹配规则以尽可能避免因为前端乱七八糟导致而产生的以下导致重载失败的原因：
有些日期后面少了一个空格导致重载失败；
有些up干员的概率括号在名称前有些在名称后导致重载失败；
有些up干员名称分隔用左斜线有些用右斜线导致重载失败